### PR TITLE
Added a simple state machine to the boss locomotion

### DIFF
--- a/Assets/Prefabs/Boss.prefab
+++ b/Assets/Prefabs/Boss.prefab
@@ -40,9 +40,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8774104578281465181}
-  - component: {fileID: 8774104578281465178}
+  - component: {fileID: 2311961849941570814}
   - component: {fileID: 8774104578281465180}
   - component: {fileID: 8774104578281465183}
+  - component: {fileID: 8774104578281465178}
   m_Layer: 0
   m_Name: Boss
   m_TagString: Untagged
@@ -67,28 +68,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!195 &8774104578281465178
-NavMeshAgent:
+--- !u!114 &2311961849941570814
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8774104578281465179}
   m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 0
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be2bd144f22d4fc897670bb26d975930, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  state: 0
 --- !u!114 &8774104578281465180
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,6 +103,7 @@ MonoBehaviour:
   eyesTransform: {fileID: 8774104576896631376}
   dontCheckEveryFrame: 1
   checkPlayerPositionDelayInSeconds: 0.05
+  alwaysDrawVisionCone: 1
 --- !u!114 &8774104578281465183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -125,7 +118,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bossSpeed: 2
   bossHeight: 1.8
-  bossRadius: 0.5
+  bossGirth: 0.5
+  searchTimeInSeconds: 5
+  wanderRadius: 8
+  wanderIntervalInSeconds: 5
+  randomPatrolChance: 0.3
+--- !u!195 &8774104578281465178
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8774104578281465179}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
 --- !u!1 &8774104578378252448
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Other/Dev_BossPathfinding.unity
+++ b/Assets/Scenes/Other/Dev_BossPathfinding.unity
@@ -317,6 +317,50 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 174787725}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &187842079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 187842080}
+  - component: {fileID: 187842081}
+  m_Layer: 0
+  m_Name: PatrolPoint (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &187842080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187842079}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15.99, y: 0, z: -18.78}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &187842081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187842079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &214841633
 GameObject:
   m_ObjectHideFlags: 0
@@ -612,6 +656,226 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &269378550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 269378551}
+  - component: {fileID: 269378552}
+  m_Layer: 0
+  m_Name: PatrolPoint (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &269378551
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 269378550}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.84, y: 0, z: -19.84}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &269378552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 269378550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &307907587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 307907588}
+  - component: {fileID: 307907589}
+  m_Layer: 0
+  m_Name: PatrolPoint (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &307907588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307907587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.81, y: 0, z: -3.99}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &307907589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307907587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &434222672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 434222673}
+  - component: {fileID: 434222674}
+  m_Layer: 0
+  m_Name: PatrolPoint (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &434222673
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 434222672}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15.64, y: 0, z: -1.64}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &434222674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 434222672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &536173087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 536173088}
+  - component: {fileID: 536173089}
+  m_Layer: 0
+  m_Name: PatrolPoint (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &536173088
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536173087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -19.17, y: 0, z: -17.59}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &536173089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 536173087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &711485946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 711485947}
+  - component: {fileID: 711485948}
+  m_Layer: 0
+  m_Name: PatrolPoint (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &711485947
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 711485946}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15.63, y: 0, z: 14.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &711485948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 711485946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1068950390
 GameObject:
   m_ObjectHideFlags: 0
@@ -709,6 +973,50 @@ Transform:
   m_Father: {fileID: 249144994}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &1157345622
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1157345623}
+  - component: {fileID: 1157345624}
+  m_Layer: 0
+  m_Name: PatrolPoint (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1157345623
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1157345622}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.96, y: 0, z: 14.67}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1157345624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1157345622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1229215658
 GameObject:
   m_ObjectHideFlags: 0
@@ -1614,6 +1922,50 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
+--- !u!1 &1787953888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1787953889}
+  - component: {fileID: 1787953890}
+  m_Layer: 0
+  m_Name: PatrolPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1787953889
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787953888}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -17.97, y: 0, z: 13.29}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1787953890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787953888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1882433676
 GameObject:
   m_ObjectHideFlags: 0
@@ -1711,6 +2063,50 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1882433676}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1906872339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1906872340}
+  - component: {fileID: 1906872341}
+  m_Layer: 0
+  m_Name: PatrolPoint (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1906872340
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1906872339}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -18.44, y: 0, z: -0.62}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2051165292}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1906872341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1906872339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa7bf718e30493888469390ab6fea5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1962254118
 GameObject:
   m_ObjectHideFlags: 0
@@ -1808,6 +2204,46 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1962254118}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2051165291
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2051165292}
+  m_Layer: 0
+  m_Name: PatrolPoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2051165292
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2051165291}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1787953889}
+  - {fileID: 711485947}
+  - {fileID: 536173088}
+  - {fileID: 187842080}
+  - {fileID: 307907588}
+  - {fileID: 1906872340}
+  - {fileID: 434222673}
+  - {fileID: 1157345623}
+  - {fileID: 269378551}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &8774104578135706985
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Boss/BehaviorState.cs
+++ b/Assets/Scripts/Boss/BehaviorState.cs
@@ -1,0 +1,11 @@
+﻿namespace Boss
+{
+    public enum BehaviorState
+    {
+        Idle = 0,
+        PlayerFound = 10,
+        Attacking = 20,
+        PlayerLost = 30,
+        Stunned = 40,
+    }
+}

--- a/Assets/Scripts/Boss/BehaviorState.cs.meta
+++ b/Assets/Scripts/Boss/BehaviorState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 59a5a5cc38a64b4e94f84cdcce9615c1
+timeCreated: 1659491512

--- a/Assets/Scripts/Boss/Boss.cs
+++ b/Assets/Scripts/Boss/Boss.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace Boss
+{
+    public class Boss : MonoBehaviour
+    {
+        public BehaviorState state;
+
+        private void Start()
+        {
+            state = BehaviorState.Idle;
+        }
+    }
+}

--- a/Assets/Scripts/Boss/Boss.cs.meta
+++ b/Assets/Scripts/Boss/Boss.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be2bd144f22d4fc897670bb26d975930
+timeCreated: 1659491656

--- a/Assets/Scripts/Boss/BossLocomotion.cs
+++ b/Assets/Scripts/Boss/BossLocomotion.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Extensions;
+using UnityEngine;
 using UnityEngine.AI;
 
 namespace Boss
@@ -8,10 +11,19 @@ namespace Boss
         [Header("Agent Config")]
         [SerializeField] private float bossSpeed;
         [SerializeField] private float bossHeight;
-        [SerializeField] private float bossRadius;
-        
+        [SerializeField] private float bossGirth;
+        [SerializeField] private float searchTimeInSeconds;
+        [SerializeField] private float wanderRadius;
+        [SerializeField] private float wanderIntervalInSeconds;
+        [Range(0, 1)]
+        [SerializeField] private float randomPatrolChance;
+
+        private Boss boss;
         private NavMeshAgent agent;
         private PlayerFinder playerFinder;
+        private float playerLostTime;
+        private float nextWanderTime;
+        private List<PatrolPoint> patrolPoints;
 
         private void Awake()
         {
@@ -27,6 +39,14 @@ namespace Boss
                 Debug.LogError($"Cannot find PlayerFinder");
             }
 
+            boss = GetComponentInParent<Boss>();
+            if (boss == null)
+            {
+                Debug.LogError($"Cannot find Boss script");
+            }
+
+            patrolPoints = FindObjectsOfType<PatrolPoint>().ToList();
+
             playerFinder.OnPlayerFound += OnPlayerFound;
             playerFinder.OnPlayerKnownPosition += OnPlayerStillVisible;
             playerFinder.OnPlayerLost += OnPlayerLost;
@@ -37,32 +57,112 @@ namespace Boss
             SetUpAgent();
         }
 
+        private void Update()
+        {
+            switch (boss.state)
+            {
+                // No locomotion in these states
+                case BehaviorState.Attacking:
+                case BehaviorState.Stunned:
+                    break;
+                case BehaviorState.PlayerLost:
+                    SearchForPlayer();
+                    break;
+                case BehaviorState.PlayerFound:
+                    MoveToTarget();
+                    break;
+                case BehaviorState.Idle:
+                    TryToWander();
+                    MoveToTarget();
+                    break;
+            }
+        }
+
         [ContextMenu("Set up agent")]
         private void SetUpAgent()
         {
             agent.speed = bossSpeed;
             agent.height = bossHeight;
-            agent.radius = bossRadius;
+            agent.radius = bossGirth;
+            agent.updatePosition = false;  // We're moving the agent manually
         }
 
-        private void MoveToTarget(Vector3 target)
+        private void MoveToTarget()
+        {
+            transform.position = agent.nextPosition;
+            // See here to couple locomotion with animation:
+            // https://docs.unity3d.com/Manual/nav-CouplingAnimationAndNavigation.html
+        }
+
+        private void TryToWander()
+        {
+            if (Time.time < nextWanderTime) return;
+            Vector3 pos;
+            if (Random.value > randomPatrolChance && patrolPoints.Count > 0)
+            {
+                pos = patrolPoints.Choose().transform.position;
+            }
+            else
+            {
+                var hit = GetRandomNavMeshPosition();
+                pos = hit.position;
+            }
+            agent.SetDestination(pos);
+            nextWanderTime = Time.time + wanderIntervalInSeconds;
+        }
+
+        private NavMeshHit GetRandomNavMeshPosition()
+        {
+            var randomDirection = Random.insideUnitSphere * wanderRadius;
+            randomDirection += transform.position;
+            NavMesh.SamplePosition(randomDirection, out var hit, wanderRadius, 1);
+            return hit;
+        }
+
+        private void SearchForPlayer()
+        {
+            if (agent.hasPath)
+            {
+                MoveToTarget();
+                playerLostTime = Time.time + searchTimeInSeconds;
+
+                var rotationDirection = Mathf.Sin(Time.time) > 0 ? 1 : -1;
+                transform.Rotate(transform.up, agent.angularSpeed * Time.deltaTime * rotationDirection);
+                return;
+            }
+            
+            if (Time.time > playerLostTime)
+            {
+                boss.state = BehaviorState.Idle;
+            }
+            // TODO: Replace with a "searching" animation
+            transform.Rotate(transform.up, agent.angularSpeed * Time.deltaTime);
+        }
+
+        private void SetTarget(Vector3 target)
         {
             agent.SetDestination(target);
         }
 
         private void OnPlayerFound(Vector3 playerPos)
         {
-            MoveToTarget(playerPos);
+            SetTarget(playerPos);
+            if (boss.state is BehaviorState.Idle or BehaviorState.PlayerLost)
+            {
+                boss.state = BehaviorState.PlayerFound;
+            }
         }
 
         private void OnPlayerStillVisible(Vector3 playerPos)
         {
-            MoveToTarget(playerPos);
+            SetTarget(playerPos);
         }
 
         private void OnPlayerLost(Vector3 playerLastKnownPos)
         {
-            MoveToTarget(playerLastKnownPos);
+            SetTarget(playerLastKnownPos);
+            boss.state = BehaviorState.PlayerLost;
+            playerLostTime = Time.time + searchTimeInSeconds;
         }
     }
 }

--- a/Assets/Scripts/Boss/PatrolPoint.cs
+++ b/Assets/Scripts/Boss/PatrolPoint.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Boss
+{
+    public class PatrolPoint : MonoBehaviour
+    {
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (Selection.count == 0 || Selection.activeGameObject.GetComponentInChildren<PatrolPoint>() == null) return;
+            
+            Handles.color = Color.blue;
+            Handles.DrawSolidDisc(transform.position, transform.up, 0.3f);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Boss/PatrolPoint.cs.meta
+++ b/Assets/Scripts/Boss/PatrolPoint.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9aa7bf718e30493888469390ab6fea5b
+timeCreated: 1659495434

--- a/Assets/Scripts/Extensions.meta
+++ b/Assets/Scripts/Extensions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 57cdc1a75af84b5da74fe2ac3abd25fc
+timeCreated: 1659495530

--- a/Assets/Scripts/Extensions/Extensions.cs
+++ b/Assets/Scripts/Extensions/Extensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Extensions
+{
+    public static class Extensions
+    {
+        public static T Choose<T>(this List<T> list)
+        {
+            return
+                list.Count == 0 ?
+                default :
+                list[Mathf.RoundToInt(Random.value * list.Count - 1)];
+        }
+    }
+}

--- a/Assets/Scripts/Extensions/Extensions.cs.meta
+++ b/Assets/Scripts/Extensions/Extensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94321dca747a4cff8ed3cefe36041080
+timeCreated: 1659495542


### PR DESCRIPTION
The boss locomotion script switches between pursuing the player, searching for the player and patrolling. It also has another two states, attacking and stunned where it doesn't move.

The wandering / patrolling behavior is random. It randomly selects whether to wander or patrol every wander interval (the ratio between the two as well as the length of the interval are tunable). If the level has patrol points, it chooses a random one and heads there. If not (or if it hits the "wander chance"), it chooses a point at random from the navmesh up to a tunable distance.

When pursuing the player, if it loses sight of the player for more than 5 seconds (tunable), it heads toward the last known location, looking around as it moves. Once at that location it does a 360deg scan of the area for another 5 seconds (also tunable separately) and if it still cannot find the player it goes back to patrolling / wandering.