### PR TITLE
Fixed Projectile Spitter / Edited Laser On player found

### DIFF
--- a/Assets/Prefabs/Boss/Projectiles/Fireball.prefab
+++ b/Assets/Prefabs/Boss/Projectiles/Fireball.prefab
@@ -9857,7 +9857,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 3
+  m_CollisionDetection: 1
 --- !u!114 &5084862213373338596
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9875,7 +9875,7 @@ MonoBehaviour:
   DamagingCollider: {fileID: 2324668574953617845}
   ColliderRigidbody: {fileID: 0}
   _lastDamageForce: 0
-  _destroyOnDamaging: 0
+  _destroyOnDamaging: 1
   CraftingSocketMat: {fileID: 0}
   _projectileSpawner: {fileID: 0}
   _layerToIgnore: Enemy

--- a/Assets/Prefabs/Boss/Projectiles/Sludge.prefab
+++ b/Assets/Prefabs/Boss/Projectiles/Sludge.prefab
@@ -114,7 +114,7 @@ Rigidbody:
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
-  m_CollisionDetection: 3
+  m_CollisionDetection: 1
 --- !u!114 &8870672126910543913
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -132,7 +132,7 @@ MonoBehaviour:
   DamagingCollider: {fileID: 2146277150381384312}
   ColliderRigidbody: {fileID: 0}
   _lastDamageForce: 0
-  _destroyOnDamaging: 0
+  _destroyOnDamaging: 1
   CraftingSocketMat: {fileID: 0}
   _projectileSpawner: {fileID: 0}
   _layerToIgnore: Enemy

--- a/Assets/Prefabs/Player/XR Origin Custom.prefab
+++ b/Assets/Prefabs/Player/XR Origin Custom.prefab
@@ -3947,7 +3947,7 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 1.36144
+  m_Height: 1.1
   m_Radius: 0.2
   m_SlopeLimit: 45
   m_StepOffset: 0.3

--- a/Assets/Scenes/Level/LevelBlockout Alternative Trash Spawns.unity
+++ b/Assets/Scenes/Level/LevelBlockout Alternative Trash Spawns.unity
@@ -1995,7 +1995,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &333511854
 PrefabInstance:
@@ -4105,7 +4105,7 @@ Transform:
   m_Children:
   - {fileID: 976141632}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &623373139
 GameObject:
@@ -4206,6 +4206,75 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3256375178060001140, guid: e690904d5b6e94549a578f5b45eca466, type: 3}
   m_PrefabInstance: {fileID: 646538341}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &654133832
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 424517531141095325, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: _boss
+      value: 
+      objectReference: {fileID: 819856863}
+    - target: {fileID: 424517531141095325, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: _bossRespawnTransform
+      value: 
+      objectReference: {fileID: 53014012}
+    - target: {fileID: 424517531141095325, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: _playerRespawnTransform
+      value: 
+      objectReference: {fileID: 413601344}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -46.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.018
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071079
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.70710576
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759392, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759453, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_Name
+      value: XR Origin Custom (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
 --- !u!1001 &666208995
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5492,11 +5561,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 8774104578281465179, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
   m_PrefabInstance: {fileID: 1915871794}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &819856870 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8774104578281465181, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
-  m_PrefabInstance: {fileID: 1915871794}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &838488707
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5830,7 +5894,7 @@ Transform:
   m_Children:
   - {fileID: 469860604}
   m_Father: {fileID: 1774913632}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &908169737
 PrefabInstance:
@@ -11698,7 +11762,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1744731614
 GameObject:
@@ -12020,10 +12084,9 @@ Transform:
   m_Children:
   - {fileID: 1993284524}
   - {fileID: 1868824234}
-  - {fileID: 819856870}
   - {fileID: 905224152}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1787747644
 PrefabInstance:
@@ -13168,7 +13231,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1774913632}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 3811999563029068489, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: onDestroyed.m_PersistentCalls.m_Calls.Array.size
@@ -13210,6 +13273,10 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 84831a1fb55befa48a7d8a7e541999b5, type: 2}
+    - target: {fileID: 8774104578281465178, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
+      propertyPath: m_Speed
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 8774104578281465179, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: m_Name
       value: Boss
@@ -13220,7 +13287,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8774104578281465181, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8774104578281465181, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: m_LocalScale.x
@@ -13240,7 +13307,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8774104578281465181, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6282228
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8774104578281465181, guid: b2c1efcf15a23104f80feeb91f15b624, type: 3}
       propertyPath: m_LocalPosition.z
@@ -15283,6 +15350,10 @@ PrefabInstance:
     - target: {fileID: 6401763131585759453, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
       propertyPath: m_Name
       value: XR Origin Custom
+      objectReference: {fileID: 0}
+    - target: {fileID: 6401763131585759453, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 99719a952ebeb9d4f87dc43833721a5d, type: 3}

--- a/Assets/Scripts/Boss/Attacks/LaserLimb.cs
+++ b/Assets/Scripts/Boss/Attacks/LaserLimb.cs
@@ -105,14 +105,14 @@ public class LaserLimb : AttackBase
     }
 
     private void OnPlayerFound(Player.Player player)
-    {
-        target = player.transform;
+    {        
+        //target = player.transform;
         foundPlayer = true;
     }
 
     private void OnPlayerLost(Player.Player player)
     {
-        target = null;
+        //target = null;
         foundPlayer = false;
     }
 }

--- a/Assets/Scripts/Boss/Attacks/ProjectileSpitter.cs
+++ b/Assets/Scripts/Boss/Attacks/ProjectileSpitter.cs
@@ -22,6 +22,8 @@ namespace VRJammies.Framework.Core.Boss
         [SerializeField] private PlayerFinder playerFinder;
 
 
+        private bool _shouldPool = false;
+
         [SerializeField]
         private float _attackSpeed = 0.125f;
         private float _timer = 0f;
@@ -61,49 +63,37 @@ namespace VRJammies.Framework.Core.Boss
 
         private void SpawnProjectile()
         {
-            bool didSpawn = false;
+            if (_shouldPool)
+            {
+                bool didSpawn = false;
 
-            // Check the projectile list for inactive projectiles
-            foreach (var projectile in _projectileList)
-            {
-                if (!projectile.activeSelf)
-                {
-                    // If you found an inactive object, use that and tick of didSpawn as true
-                    projectile.transform.position = this.transform.position;
-                    projectile.SetActive(true);
-                    ShootProjectile(projectile);
-                    didSpawn = true;
-                    break;
-                }
-            }
-
-            // If after the loop there was no inactive object, spawn a new one
-            if (!didSpawn)
-            {
-                var projectile = Instantiate(_projectilePrefab, _output.position, _output.rotation);
-                _projectileList.Add(projectile);
-                ShootProjectile(projectile);
-            }
-
-            /*
-            if (_projectileList.Count < _maxProjectiles)
-            {
-                var projectile = Instantiate(_projectilePrefab, _output.position, _output.rotation);
-                _projectileList.Add(projectile);
-                ShootProjectile(projectile);
-            }
-            else
-            {
+                // Check the projectile list for inactive projectiles
                 foreach (var projectile in _projectileList)
                 {
                     if (!projectile.activeSelf)
                     {
+                        // If you found an inactive object, use that and tick of didSpawn as true
+                        projectile.transform.position = this.transform.position;
+                        projectile.SetActive(true);
                         ShootProjectile(projectile);
+                        didSpawn = true;
                         break;
                     }
                 }
+
+                // If after the loop there was no inactive object, spawn a new one
+                if (!didSpawn)
+                {
+                    var projectile = Instantiate(_projectilePrefab, _output.position, _output.rotation);
+                    _projectileList.Add(projectile);
+                    ShootProjectile(projectile);
+                }
             }
-            */
+            else
+            {
+                var projectile = Instantiate(_projectilePrefab, _output.position, _output.rotation);
+                ShootProjectile(projectile);
+            }
         }
 
         private void ShootProjectile(GameObject projectile)


### PR DESCRIPTION
Projectile Spitter Projectile Pooling threw null exception when the projectile was destroyed. Commented out the pooling, now back to instantiating and destroying projectiles which works.

Laser threw null exception when the laser started to prepare an attack and the boss lost vision of the player.
Commented out the on player lost target = null funciton.